### PR TITLE
Update Derpibooru support, Add other Boorus

### DIFF
--- a/boorutagparser.user.js
+++ b/boorutagparser.user.js
@@ -207,19 +207,19 @@ function copyBooruTags(noRating)
     insertTags(tags, 'li.tag-type-faults > a', 'fault:');
 
     // derpibooru-like
-    insertTags(tags, '.tag-list [data-tag-category="origin"]:not([data-tag-name="edit"]):not([data-tag-slug="derpibooru+exclusive"]):not([data-tag-slug="edited+screencap"]):not([data-tag-slug="screencap"]):not([data-tag-slug="anonymous+artist"]) > a', 'creator:', true); //Fixes a problem where the tag parser script would fail to get work on pages with these tags, or multiple of these tags.
+    insertTags(tags, '.tag-list [data-tag-category="origin"]:not([data-tag-name="edit"]):not([data-tag-slug="derpibooru+exclusive"]):not([data-tag-slug="edited+screencap"]):not([data-tag-slug="screencap"]):not([data-tag-slug="anonymous+artist"]) > a', 'creator:', true); //Fixes a problem where the tag parser script would fail to work on pages with these tags, or multiple of these tags.
     insertTags(tags, '.tag-list .tag.tag-ns-oc > a', 'character:', true);
     insertTags(tags, '.tag-list .tag.tag-system > a', 'rating:');
     insertTags(tags, '.tag-list [class="tag dropdown"]:not([data-tag-category="character"]):not([data-tag-category="origin"]):not([data-tag-category="spoiler"]):not([data-tag-category="episode"]) > a', ''); // generic tags on derpibooru do not have a "namespace" class of their own, this seems to be the best way to match generic tags
     insertTags(tags, '.tag-list [data-tag-category="character"] > a', 'character:'); // grabs the new character tags on Derpibooru and gives them a proper character namespace for Hydrus
     insertTags(tags, '.tag-list [data-tag-category="episode"] > a', 'episode:'); // grabs the show episode title and gives it an episode namespace for Hydrus
-    insertTags(tags, '[data-tag-name="edit"] > a', '') //Since derpibooru for some reason has edits tagged as an artist, this converts that to a general edit tag
-    insertTags(tags, '[data-tag-slug="derpibooru+exclusive"] > a', '') //Since derpibooru for some reason has derpi exclusives tagged as an artist, this converts that to a general tag
+    insertTags(tags, '[data-tag-name="edit"] > a', '') //Since derpibooru has edits tagged as an artist, this converts that to a general edit tag
+    insertTags(tags, '[data-tag-slug="derpibooru+exclusive"] > a', '') //Since derpibooru has derpi exclusives tagged as an artist, this converts that to a general tag
     insertTags(tags, '[data-tag-slug="edited+screencap"] > a', '') //makes the edited screencap into a general tag
     insertTags(tags, '[data-tag-slug="screencap"] > a', '') //Makes the screencap tag into a general tag
     insertTags(tags, '[data-tag-slug="anonymous+artist"] > a', '') //Makes Anon Artist into a general tag which Hydrus will then convert into a creator tag via tag siblings  
     
-    //SoFurry like
+    // sofurry like
     insertTags(tags, '.titlehover > a', '')
     
     // booru.org-like


### PR DESCRIPTION
This is a collection of fixes and updates from anons in the 8chan thread for the parser, along with my own fixes to update support for Derpibooru's new tag changes. This version of the code also downloads the short ID named version of Derpibooru images rather than the long named version. Support is also added for SoFurry tags, though the parser might have trouble with some of them. Some new booru website additions for more booru compatibility are also included. 

You may not want to merge the version # change (or update it yourself). 