### PR TITLE
Small fix for Danbooru grabbing samples

### DIFF
--- a/boorutagparser.user.js
+++ b/boorutagparser.user.js
@@ -356,7 +356,7 @@ function doDownload()
 {
     var a = document.querySelector('a.original-file-unchanged');
     if (!a)
-        a = document.querySelector('a#highres, a[itemprop="contentSize"], li > a[href*="/images/"], section#image-container > a > img, img#image, img[src*="/_images/"], a[href*="/img/download"][title="Download (short filename)"], a[href*="/img/download"][title="Download (no tags in filename)"], form[action*="/_images/"], source[src]');
+        a = document.querySelector('a[href*="/data/_"], #post-information > ul > li > a[href*="/__"], a#highres, a[itemprop="contentSize"], li > a[href*="/images/"], section#image-container > a > img, img#image, img[src*="/_images/"], a[href*="/img/download"][title="Download (short filename)"], a[href*="/img/download"][title="Download (no tags in filename)"], form[action*="/_images/"], source[src]');
 
     if (!a)
         return;


### PR DESCRIPTION
Makes a small addition to the doDownload querySelector as it was grabbing sample images from danbooru.
I don't know much about JS or CSS but it works.