### PR TITLE
Patching in new tag presentation style of danbooru

### DIFF
--- a/boorutagparser.user.js
+++ b/boorutagparser.user.js
@@ -1,11 +1,11 @@
 // ==UserScript==
 // @name         Booru Tag Parser
 // @namespace    http://average.website
-// @version      1.1.4
-// @description  Copy current post tags and rating on boorus and illustration2vec in to the clipboard for easy import in to a program or another booru.
-// @author       William Moodhe
-// @downloadURL  https://github.com/JetBoom/boorutagparser/raw/master/boorutagparser.user.js
-// @updateURL    https://github.com/JetBoom/boorutagparser/raw/master/boorutagparser.user.js
+// @version      1.1.5
+// @description  Copy current post tags and rating on boorus and illustration2vec in to the clipboard for easy import in to a program or another booru. (fork will not replace underscores with spaces and fixes new danbooru tag data presentation)
+// @author       William Moodhe (fork by GlassedSilver)
+// @downloadURL  https://github.com/GlassedSilver/boorutagparser/raw/master/boorutagparser.user.js
+// @updateURL    https://github.com/GlassedSilver/boorutagparser/raw/master/boorutagparser.user.js
 
 // Illustration2Vec
 // @include      *demo.illustration2vec.net*
@@ -89,7 +89,7 @@ function insertTags(tags, selector, prefix, stripns)
         var text = element.innerHTML;
         if (text.length > 1) // Don't copy - + or ?
         {
-            text = replaceAll(text, '_', ' ');
+            // text = replaceAll(text, '_', ' ');      /* Personal preference: Some users need underscores, some need spaces */
             text = replaceAll(text, '&gt;', '>');
             text = replaceAll(text, '&lt;', '<');
 

--- a/boorutagparser.user.js
+++ b/boorutagparser.user.js
@@ -2,10 +2,10 @@
 // @name         Booru Tag Parser
 // @namespace    http://average.website
 // @version      1.1.5
-// @description  Copy current post tags and rating on boorus and illustration2vec in to the clipboard for easy import in to a program or another booru. (fork will not replace underscores with spaces and fixes new danbooru tag data presentation)
-// @author       William Moodhe (fork by GlassedSilver)
-// @downloadURL  https://github.com/GlassedSilver/boorutagparser/raw/master/boorutagparser.user.js
-// @updateURL    https://github.com/GlassedSilver/boorutagparser/raw/master/boorutagparser.user.js
+// @description  Copy current post tags and rating on boorus and illustration2vec in to the clipboard for easy import in to a program or another booru.
+// @author       William Moodhe
+// @downloadURL  https://github.com/JetBoom/boorutagparser/raw/master/boorutagparser.user.js
+// @updateURL    https://github.com/JetBoom/boorutagparser/raw/master/boorutagparser.user.js
 
 // Illustration2Vec
 // @include      *demo.illustration2vec.net*
@@ -89,7 +89,7 @@ function insertTags(tags, selector, prefix, stripns)
         var text = element.innerHTML;
         if (text.length > 1) // Don't copy - + or ?
         {
-            // text = replaceAll(text, '_', ' ');      /* Personal preference: Some users need underscores, some need spaces */
+            text = replaceAll(text, '_', ' ');
             text = replaceAll(text, '&gt;', '>');
             text = replaceAll(text, '&lt;', '<');
 

--- a/boorutagparser.user.js
+++ b/boorutagparser.user.js
@@ -187,8 +187,14 @@ function copyBooruTags(noRating)
 {
     var tags = [];
     // Instead of having a list of boorus and their tags and tag structures I just make a big catch-all.
+    
+    // danbooru-like-new
+    insertTags(tags, '#tag-list li.tag-type-3 > a.search-tag', 'series:');
+    insertTags(tags, '#tag-list li.tag-type-1 > a.search-tag', 'creator:');
+    insertTags(tags, '#tag-list li.tag-type-4 > a.search-tag', 'character:');
+    insertTags(tags, '#tag-list li.tag-type-0 > a.search-tag', '');    
 
-    // danbooru-like
+    // danbooru-like-old
     insertTags(tags, '#tag-list li.category-3 > a.search-tag', 'series:');
     insertTags(tags, '#tag-list li.category-1 > a.search-tag', 'creator:');
     insertTags(tags, '#tag-list li.category-4 > a.search-tag', 'character:');


### PR DESCRIPTION
Recently boorutagparser broke due to a change in how danbooru presents data to us.

I suspect it's this commit: https://github.com/danbooru/danbooru/commit/72e56d8856dab7bde089914682a55fc648152638

Regardless, boorus based on the new style should now be supported.

This will close issue #10 .