### PR TITLE
idol tag wasn't being copied on sancom

### DIFF
--- a/boorutagparser.user.js
+++ b/boorutagparser.user.js
@@ -206,6 +206,7 @@ function copyBooruTags(noRating)
     insertTags(tags, 'li.tag-type-artist > a', 'creator:');
     insertTags(tags, 'li.tag-type-character > a', 'character:');
     insertTags(tags, 'li.tag-type-model > a', 'model:');
+    insertTags(tags, 'li.tag-type-idol > a', 'model:');
     insertTags(tags, 'li.tag-type-general > a', '');
     insertTags(tags, 'li.tag-type-studio > a', 'studio:');
     insertTags(tags, 'li.tag-type-circle > a', 'studio:');


### PR DESCRIPTION
Fix for the idol tag on idol.sankakucomplex.com not being copied.