### PR TITLE
Add ai-model tag for AIBooru

### DIFF
--- a/boorutagparser.user.js
+++ b/boorutagparser.user.js
@@ -193,6 +193,8 @@ function copyBooruTags(noRating)
     insertTags(tags, '#tag-list li.tag-type-3 > a.search-tag', 'series:');
     insertTags(tags, '#tag-list li.tag-type-1 > a.search-tag', 'creator:');
     insertTags(tags, '#tag-list li.tag-type-4 > a.search-tag', 'character:');
+    insertTags(tags, '#tag-list li.tag-type-5 > a.search-tag', 'meta:');
+    insertTags(tags, '#tag-list li.tag-type-6 > a.search-tag', 'ai-model:'); // AI models for AIBooru
     insertTags(tags, '#tag-list li.tag-type-0 > a.search-tag', '');    
 
     // danbooru-like-old


### PR DESCRIPTION
https://aibooru.online/

May cause problems for other boorus based on Danbooru if they're using li.tag-type-6 for other things.